### PR TITLE
:bug: fixing multiple syntax errors

### DIFF
--- a/pull_requests.rb
+++ b/pull_requests.rb
@@ -1,10 +1,5 @@
-# Fixed these bugs and pull request
-
-# 1. Bug
 number = 2
-if ( number = 2 ) {           ## (2 == number)
-  put 'Number value is two'
-}
 
-# 2. Bug
-12.reverse                    ## 12.to_s.reverse
+puts 'Number value is two' if number == 2
+
+12.to_s.reverse


### PR DESCRIPTION
With this PR

* Fix wrong usage of curly braces
* Add a `to_s` method for reverse method since an integer can't be reversed
* Use guard clause instead of block `if` statement